### PR TITLE
Add GET request check in service worker fetch

### DIFF
--- a/source/sw.js
+++ b/source/sw.js
@@ -48,12 +48,14 @@ self.addEventListener('activate', event => {
   );
 });
 
+const isSameOrigin = (request, orgin) => request.url.startsWith(origin);
+const isGetRequest = (request) => request.method.toLowerCase() === 'get';
 // The fetch handler serves responses for same-origin resources from a cache.
 // If no response is found, it populates the runtime cache with the response
 // from the network before returning it to the page.
 self.addEventListener('fetch', event => {
   // Skip cross-origin requests, like those for Google Analytics.
-  if (event.request.url.startsWith(self.location.origin)) {
+  if (isSameOrigin(event.request, self.location.origin) && isGetRequest(event.request)) {
     event.respondWith(
       caches.match(event.request).then(cachedResponse => {
         if (cachedResponse) {


### PR DESCRIPTION
The error:

"Uncaught (in promise) TypeError: Request method 'POST' is unsupported"

happended before.
Post was called by browser-sync, which is an indicator for the
development environment.

With that change http://127.0.0.1:3000 behaves like production and the
service worker can be debugged.